### PR TITLE
Fix off-by-two error in ModRM display

### DIFF
--- a/browser/site/site.coffee
+++ b/browser/site/site.coffee
@@ -64,7 +64,7 @@ $ ->
       if code.modrm? && code.modrm.length > 0
         $(".modrm").show()
         modrm = parseInt('0x'+code.modrm).toString(2)
-        for i in [modrm.length..7]
+        for i in [modrm.length...8]
           modrm = "0" + modrm
         ret = ''
         for m in [0..7]

--- a/browser/site/site.js
+++ b/browser/site/site.js
@@ -80,7 +80,7 @@
         if ((code.modrm != null) && code.modrm.length > 0) {
           $(".modrm").show();
           modrm = parseInt('0x' + code.modrm).toString(2);
-          for (i = _m = _ref2 = modrm.length; _ref2 <= 7 ? _m <= 7 : _m >= 7; i = _ref2 <= 7 ? ++_m : --_m) {
+          for (i = _m = _ref2 = modrm.length; _ref2 <= 8 ? _m < 8 : _m > 8; i = _ref2 <= 8 ? ++_m : --_m) {
             modrm = "0" + modrm;
           }
           ret = '';


### PR DESCRIPTION
The padding for the ModRM byte is off by two, this fixes it.
